### PR TITLE
Make hash method return whole numbers

### DIFF
--- a/src/components/sandbox/utils.js
+++ b/src/components/sandbox/utils.js
@@ -10,7 +10,7 @@ function calculateNotificationContentHash(content) {
       .map(function(x) { return x.charCodeAt(0); })
       .reduce(function(x, y) { return x + y; });
   } else if (typeof content === "number") {
-    return content * SOME_PRIME_NUMBER;
+    return parseInt(content) * SOME_PRIME_NUMBER;
   } else if (typeof content === 'boolean') {
     return content ? SOME_PRIME_NUMBER : SOME_PRIME_NUMBER*3;
   }


### PR DESCRIPTION
Noticed the marble color for `average` looked off (https://github.com/staltz/rxmarbles/issues/8), made the hash function return whole numbers as a fix. What do you think?