### PR TITLE
WIP: Add link to documentation

### DIFF
--- a/src/components/sandbox/sandbox.js
+++ b/src/components/sandbox/sandbox.js
@@ -19,7 +19,14 @@ function renderOperatorLabel(label) {
     fontWeight: '400',
     fontSize: `${fontSize}rem`
   };
-  return h('span.operatorLabel', {style}, label);
+  let docLinkStyle = {
+    fontSize: `0.8rem`,
+    display: 'block',
+    marginTop: '5px'
+  };
+  let operatorName = label.split('(')[0].toLowerCase();
+  let href = `https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/core/operators/${operatorName}.md`;
+  return [h('span.operatorLabel', {style}, label), h('a', {style: docLinkStyle, href}, `See Documentation`)];
 }
 
 function renderOperator(label) {


### PR DESCRIPTION
Just a starting point. Might look better with the link under sandbox. Note cannot click on link at the moment as elevation2before and elevation2after blocking click event somehow. 
![image](https://cloud.githubusercontent.com/assets/1134912/13372042/20c8e33c-dd82-11e5-9677-d1552246fe37.png)
