### PR TITLE
Add support for draggable error and complete marbles.

### DIFF
--- a/TODO
+++ b/TODO
@@ -76,6 +76,7 @@ DONE Fix marble hover and dragging styles for Firefox
 DONE Fix affordance animation stuck for combineLatest
 >>> v1.4.0
 
+DONE Add support for draggable error and complete marbles.
 TODO Fix visual semantics of concat diagram
 >>>
 

--- a/src/components/sandbox/sandbox.js
+++ b/src/components/sandbox/sandbox.js
@@ -31,6 +31,13 @@ export function Sandbox({ DOM, store }) {
         // route change. Skip it.
         .skip(1)
         .startWith(inputsToTimelines(example.inputs))
+        .map(timelines => timelines.map(timeline => { // note: We modify the timelines object here.
+            const endTimes = timeline.marbles.filter(marble => (marble.content === 'X') || (marble.content === '|')).map(marble => marble.time);
+            const endTime = Math.min.apply(null, endTimes);
+            timeline.marbles.forEach(marble => { marble.pastEnd = (marble.time > endTime); });
+            return timeline;
+        })
+        )
     )
     .publishReplay(1).refCount();
 

--- a/src/components/timeline/marble.js
+++ b/src/components/timeline/marble.js
@@ -21,24 +21,36 @@ const POSSIBLE_COLORS = [COLORS.blue, COLORS.green, COLORS.yellow, COLORS.red];
 
 function view(sources, value$, isHighlighted$) {
   return Observable.combineLatest(
-    sources.id, sources.content, value$, isHighlighted$)
-    .map(([id, content, value, isHighlighted]) =>
+    sources.id, sources.content, sources.pastEnd, value$, isHighlighted$)
+    .map(([id, content, pastEnd, value, isHighlighted]) =>
       svg.g({
         attrs: { class: ELEMENT_CLASS, transform: `translate(${value}, 5)` },
         style: { cursor: isHighlighted ? 'ew-resize' : 'default'  },
       }, [
-        svg.circle({
+        ((content === 'X') || (content === '|'))
+        ? svg.rect({
+          attrs: { x: -MARBLE_SIZE, y: -MARBLE_SIZE, width: 2*MARBLE_SIZE, height: 2*MARBLE_SIZE },
+          style: merge({
+            fill: pastEnd ? COLORS.greyLight : POSSIBLE_COLORS[id % POSSIBLE_COLORS.length],
+            stroke: pastEnd ? COLORS.grey : 'black',
+            strokeWidth: STROKE_WIDTH,
+          }, isHighlighted ? dropshadow : {}),
+        })
+        : svg.circle({
           attrs: { r: MARBLE_SIZE },
           style: merge({
-            fill: POSSIBLE_COLORS[id % POSSIBLE_COLORS.length],
-            stroke: 'black',
+            fill: pastEnd ? COLORS.greyLight : POSSIBLE_COLORS[id % POSSIBLE_COLORS.length],
+            stroke: pastEnd ? COLORS.grey : 'black',
             strokeWidth: STROKE_WIDTH,
           }, isHighlighted ? dropshadow : {}),
         }),
         svg.text({
           attrs: {
             'text-anchor': 'middle', y: '0.8' },
-          style: mergeStyles({ fontSize: '2.5px' }, fontBase, userSelectNone),
+          style: mergeStyles({
+              fontSize: '2.5px',
+              fill: pastEnd ? COLORS.grey : 'black',
+            }, fontBase, userSelectNone),
         }, [`${content}`]),
       ]),
     );

--- a/src/data/combination-examples.js
+++ b/src/data/combination-examples.js
@@ -29,8 +29,8 @@ export const combinationExamples = {
   merge: {
     label: 'merge',
     inputs: [
-      [{t:0, c:20}, {t:15, c:40}, {t:30, c:60}, {t:45, c:80}, {t:60, c:100}],
-      [{t:37, c:1}, {t:68, c:1}]
+      [{t:0, c:20}, {t:15, c:40}, {t:30, c:60}, {t:45, c:80}, {t:60, c:100}, {t:78, c:'|'}, {t:88, c:'X'}],
+      [{t:37, c:1}, {t:68, c:1}, {t:78, c:'|'}, {t:88, c:'X'}]
     ],
     apply: function(inputs) {
       return Observable.merge(...inputs);


### PR DESCRIPTION
Added support for draggable error and complete marbles.
Added those marbles to 'merge' as an example.
Adding those to the rest of examples should be part of following tasks ("Add examples related to errors", "Interactively add/remove marbles from an InputStream" in TODO).