### PR TITLE
race operation: changed relative timings

### DIFF
--- a/src/data/combination-examples.js
+++ b/src/data/combination-examples.js
@@ -41,7 +41,7 @@ export const combinationExamples = {
     label: 'race',
     inputs: [
       [{t:10, c:20}, {t:20, c:40}, {t:30, c:60}],
-      [{t:5, c:1}, {t:15, c:2}, {t:25, c:3}],
+      [{t:5, c:1}, {t:55, c:2}, {t:65, c:3}],
       [{t:20, c:0}, {t:32, c:0}, {t:44, c:0}]
     ],
     apply: function(inputs) {


### PR DESCRIPTION
The previous example was a bit ambigous: 
It could have said:

> The first responding observable is passed on.

Or it could  have said: 

> The first incoming response is taken as first in the result. Then the second element in the result is taken from whatever observable provides its second element before all others provide their second element.

This can be understood with a bit of thinking and googling but the diagram should be as unambiguous as possible. 

Moving the last 2 elements of the 'winning' observable further to the right clears up that ambiguity. 